### PR TITLE
 Rename TestRunner to SimpleUnitTesting

### DIFF
--- a/Source/Editor/SimpleUnitTesting.cs
+++ b/Source/Editor/SimpleUnitTesting.cs
@@ -9,7 +9,7 @@ using FlaxCommunity.UnitTesting;
 
 namespace FlaxCommunity.UnitTesting.Editor
 {
-    public class TestRunner : EditorPlugin
+    public class SimpleUnitTesting : EditorPlugin
     {
         private static readonly List<Type> _suites = new List<Type>();
         private MainMenuButton _mmBtn;
@@ -24,7 +24,7 @@ namespace FlaxCommunity.UnitTesting.Editor
             IsBeta = false,
             Name = "Simple Unit Testing",
             SupportedPlatforms = new PlatformType[] { PlatformType.Windows },
-            Version = new Version(1, 1),
+            Version = new Version(1, 2),
             RepositoryUrl = "https://github.com/FlaxCommunityProjects/FlaxUnitTesting"
         };
 

--- a/UnitTests.Editor.csproj
+++ b/UnitTests.Editor.csproj
@@ -61,9 +61,9 @@
     <Compile Include="Cache\AssemblyInfo.cs" />
     <Compile Include="Source\Editor\Assert.cs" />
     <Compile Include="Source\Editor\ExampleClass.cs" />
+    <Compile Include="Source\Editor\SimpleUnitTesting.cs" />
     <Compile Include="Source\Editor\TestAttributes.cs" />
     <Compile Include="Source\Editor\TestCaseData.cs" />
-    <Compile Include="Source\Editor\TestRunner.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
I renamed `TestRunner.cs` to `SimpleUnitTesting.cs`, because the FlaxEngine takes the editor plugin's file name as the default name when exporting a plugin.
